### PR TITLE
Synchronized client-side countdown and stub in temporary users

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Leaderboard from './components/Leaderboard.js';
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import {auth, db} from './firebase.js';
 import * as constants from './constants/Stages.js';
+import * as usertypes from './constants/UserTypes.js';
 
 class App extends React.Component {
   
@@ -27,12 +28,12 @@ class App extends React.Component {
 
     auth.onAuthStateChanged((user) => {
         if (user) {
-            let userRef = db.collection('users').doc(user.uid);
-            userRef.get().then(doc => {
+            let sessionRef = db.collection('sessions').doc(user.uid);
+            sessionRef.get().then(doc => {
                 if (!doc.exists) {
                     // this is a new user - setup
-                    userRef.set({
-                        type: "Spectator",
+                    sessionRef.set({
+                        type: usertypes.SPECTATOR,
                         profile: null,
                     });
                 } else {

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import logo from './logo.svg';
 import './App.css';
 import Splash from './components/Splash.js';
 import Admin from './components/Admin.js';
@@ -7,7 +6,7 @@ import CharacterSelect from './components/CharacterSelect.js';
 import Quiz from './components/Quiz.js';
 import Leaderboard from './components/Leaderboard.js';
 import { BrowserRouter as Router, Route } from "react-router-dom";
-import {db} from './firebase.js';
+import {auth, db} from './firebase.js';
 import * as constants from './constants/Stages.js';
 
 class App extends React.Component {
@@ -19,6 +18,32 @@ class App extends React.Component {
 
   componentDidMount() {
     let self = this;
+
+    auth.signInAnonymously().catch(error => {
+        // unable to sign in!
+        console.log(error.code);
+        console.log(error.message);
+    });
+
+    auth.onAuthStateChanged((user) => {
+        if (user) {
+            let userRef = db.collection('users').doc(user.uid);
+            userRef.get().then(doc => {
+                if (!doc.exists) {
+                    // this is a new user - setup
+                    userRef.set({
+                        type: "Spectator",
+                        profile: null,
+                    });
+                } else {
+                    // this is an existing user, read persisted data
+                }
+            });
+            // ...
+        } else {
+            // User is signed out.
+        }
+    });
     
     db.collection("state").doc("stage").onSnapshot(snapshot => {
         const currentStage = snapshot.data();

--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import '../styles/Admin.css';
 import * as constants from '../constants/Stages.js';
-import {db, FieldValue} from '../firebase.js';
+import * as usertypes from '../constants/UserTypes.js';
+import {auth, db, FieldValue} from '../firebase.js';
 
 const questionList = {
     listStyle: 'none'
@@ -159,6 +160,19 @@ class Admin extends React.Component {
         });
     
         self.setState({unsubscribeCallbacks: [unsubscribeQuestion, unsubscribeState, unsubscribeStage]});
+
+        auth.onAuthStateChanged((user) => {
+            if (user) {
+                let userRef = db.collection('users').doc(user.uid);
+                userRef.get().then(doc => {
+                    if (doc.exists && doc.data().type !== usertypes.ADMIN) {
+                        userRef.update({
+                            type: usertypes.ADMIN,
+                        });
+                    }
+                });
+            }
+        });
     }
 
     componentWillUnmount() {

--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -163,10 +163,10 @@ class Admin extends React.Component {
 
         auth.onAuthStateChanged((user) => {
             if (user) {
-                let userRef = db.collection('users').doc(user.uid);
-                userRef.get().then(doc => {
+                let sessionRef = db.collection('sessions').doc(user.uid);
+                sessionRef.get().then(doc => {
                     if (doc.exists && doc.data().type !== usertypes.ADMIN) {
-                        userRef.update({
+                        sessionRef.update({
                             type: usertypes.ADMIN,
                         });
                     }

--- a/src/constants/UserTypes.js
+++ b/src/constants/UserTypes.js
@@ -1,0 +1,3 @@
+export const ADMIN = "Admin";
+export const SPECTATOR = "Spectator";
+export const PLAYER = "Player";

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -14,5 +14,6 @@ const firebaseApp = firebase.initializeApp(firebaseConfig);
 
 const db = firebaseApp.firestore();
 const storage = firebaseApp.storage();
+const FieldValue = firebase.firestore.FieldValue;
 
-export { db, storage };
+export { db, storage, FieldValue };

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -12,8 +12,9 @@ const firebaseConfig = {
 
 const firebaseApp = firebase.initializeApp(firebaseConfig);
 
+const auth = firebaseApp.auth();
 const db = firebaseApp.firestore();
 const storage = firebaseApp.storage();
 const FieldValue = firebase.firestore.FieldValue;
 
-export { db, storage, FieldValue };
+export { auth, db, storage, FieldValue };


### PR DESCRIPTION
Create a sessions collection in firestore we can use to associate anonymous users to the characters they chose and (therefore) the answers they provided. I imagine the anonymous user changes every time your public IP changes, and if that's the case it's really more of a session than a user.